### PR TITLE
Update demo page and stars for Materialize theme

### DIFF
--- a/_posts/2016-01-10-materialize.markdown
+++ b/_posts/2016-01-10-materialize.markdown
@@ -2,11 +2,11 @@
 title: Materialize
 homepage: https://github.com/alexcarpenter/material-jekyll-theme
 download: https://github.com/alexcarpenter/material-jekyll-theme/archive/gh-pages.zip
-demo: http://alexcarpenter.me/material-jekyll-theme/
+demo: http://alexcarpenter.github.io/material-jekyll-theme/
 author: Alex Carpenter
 thumbnail: materialize.jpg
 license: MIT License
 license_link: https://github.com/alexcarpenter/material-jekyll-theme/blob/gh-pages/LICENSE
 github_repo: alexcarpenter/material-jekyll-theme
-stars: 129
+stars: 150
 ---


### PR DESCRIPTION
I noticed that demo link does not work, so I found current address.